### PR TITLE
rename "Sample Browser" to "Sample Library"

### DIFF
--- a/rm2000/Views/Sample Library/DetailView.swift
+++ b/rm2000/Views/Sample Library/DetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct DetailView: View {
-	@ObservedObject var viewModel: SampleBrowserViewModel
+	@ObservedObject var viewModel: SampleLibraryViewModel
 	
 	var body: some View {
 		Group {
@@ -15,7 +15,7 @@ struct DetailView: View {
 }
 
 private struct TaggedRecordingsView: View {
-	@ObservedObject var viewModel: SampleBrowserViewModel
+	@ObservedObject var viewModel: SampleLibraryViewModel
 	let selectedTag: String
 	
 	var body: some View {
@@ -28,7 +28,7 @@ private struct TaggedRecordingsView: View {
 }
 
 struct AllRecordingsView: View {
-	@ObservedObject var viewModel: SampleBrowserViewModel
+	@ObservedObject var viewModel: SampleLibraryViewModel
 	
 	var body: some View {
 		Group {
@@ -87,15 +87,3 @@ struct SampleIndividualListItem: View {
 		}
 	}
 }
-
-//#Preview("Detail View") {
-//	let vm = SampleBrowserViewModel()
-////	vm.directoryContents = [
-////		URL(string: "file:///sample1--drums_bass.wav")!,
-////		URL(string: "file:///sample2--vocals_synth.mp3")!
-////	]
-//	vm.finishedProcessing = true
-//	return DetailView(viewModel: vm)
-//}
-//
-

--- a/rm2000/Views/Sample Library/SampleLibraryView.swift
+++ b/rm2000/Views/Sample Library/SampleLibraryView.swift
@@ -4,13 +4,13 @@ import SwiftUI
 
 @MainActor
 struct SampleLibraryView: View {
-	@StateObject private var viewModel: SampleBrowserViewModel
+	@StateObject private var viewModel: SampleLibraryViewModel
 	@Environment(\.openURL) private var openURL
 	
 	@State private var totalSamples: Int = 0
 	
 	init() {
-			_viewModel = StateObject(wrappedValue: SampleBrowserViewModel())
+			_viewModel = StateObject(wrappedValue: SampleLibraryViewModel())
 	}
 	
 	var body: some View {
@@ -20,7 +20,7 @@ struct SampleLibraryView: View {
 		} detail: {
 			DetailView(viewModel: viewModel)
 		}
-		.navigationTitle("Sample Browser")
+		.navigationTitle("Sample Library")
 		.navigationSubtitle(String(totalSamples))
 		.toolbar {
 			ToolbarItem {
@@ -39,9 +39,6 @@ struct OpenInFinderButton: View {
 		Button(action: {
 			NSWorkspace.shared.open(SampleStorage.shared.UserDirectory.directory)
 		}) {
-//			Label("Open in Finder", image: "Finder")
-//				.scaledToFit()
-//				.frame(width: 34, height: 34)
 			VStack {
 				Image(nsImage: NSWorkspace.shared.icon(forFile: "/System/Library/CoreServices/Finder.app"))
 					.resizable()
@@ -58,7 +55,7 @@ struct OpenInFinderButton: View {
 
 
 @MainActor
-class SampleBrowserViewModel: ObservableObject {
+class SampleLibraryViewModel: ObservableObject {
 	@Published var sampleArray: [Sample] = []
 	@Published var indexedTags: [String] = []
 	@Published var finishedProcessing: Bool = false

--- a/rm2000/Views/Sample Library/Sidebar/SidebarView.swift
+++ b/rm2000/Views/Sample Library/Sidebar/SidebarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SidebarView: View {
-	@ObservedObject var viewModel: SampleBrowserViewModel
+	@ObservedObject var viewModel: SampleLibraryViewModel
 	
 	var body: some View {
 		List(selection: $viewModel.selectedTag) {
@@ -22,7 +22,7 @@ struct SidebarView: View {
 }
 
 #Preview("Sidebar View") {
-	let vm = SampleBrowserViewModel()
+	let vm = SampleLibraryViewModel()
 	vm.indexedTags = ["drums", "bass", "vocals"]
 	vm.finishedProcessing = true
 	return SidebarView(viewModel: vm)


### PR DESCRIPTION
`browser` makes it seem that its, like, an internet browser.

every daw that has some sort of `browsing functionality`, they call it a library